### PR TITLE
v0.5.1

### DIFF
--- a/src/lib/systemd/default-service
+++ b/src/lib/systemd/default-service
@@ -1,7 +1,7 @@
 [Unit]
 Description=#@frequency@# Adsorber service
 Documentation=https://github.com/stablestud/adsorber
-After=network-online.target
+After=network.target network-online.target
 Requisite=network-online.target
 
 [Service]

--- a/src/lib/systemd/default-timer
+++ b/src/lib/systemd/default-timer
@@ -1,8 +1,8 @@
 [Unit]
 Description=Timer that runs the Adsorber service #@frequency@#
 Documentation=https://github.com/stablestud/adsorber
-After=network-online.target
-Requisite=network-online.target
+After=network.target network-online.target
+Wants=network-online.target
 
 [Timer]
 OnCalendar=#@frequency@#

--- a/src/lib/update.sh
+++ b/src/lib/update.sh
@@ -203,15 +203,15 @@ update_FetchSources()
 
 	unset _domain
 
-        if [ "${_successful_count}" -eq 0 ]; then
-                printf "%bNothing to apply [%d/%d].\\n" "${prefix_warning}" "${_successful_count}" "${_total_count}" 1>&2
-                echo "${prefix}Perhaps a proxy server must be set?" 1>&2
-                return 1
-        elif [ "${ignore_download_error}" = "false" ] && [ "${_successful_count}" -ne "${_total_count}" ]; then
+        if [ "${ignore_download_error}" = "false" ] && [ "${_successful_count}" -ne "${_total_count}" ]; then
                 printf "%bCouldn't fetch all hosts sources [%d/%d]. Aborting ...\\n" "${prefix_warning}" "${_successful_count}" "${_total_count}" 1>&2
 
                 errorCleanUp 
                 exit 1
+        elif [ "${_successful_count}" -eq 0 ]; then
+                printf "%bNothing to apply [%d/%d].\\n" "${prefix_warning}" "${_successful_count}" "${_total_count}" 1>&2
+                echo "${prefix}Perhaps a proxy server must be set?" 1>&2
+                return 1
         else
                 printf "%bSuccessfully fetched %d out of %d hosts sources.%b\\n" "${prefix_info}" "${_successful_count}" "${_total_count}" "${prefix_reset}"
         fi

--- a/src/share/default/default-adsorber.conf
+++ b/src/share/default/default-adsorber.conf
@@ -45,7 +45,7 @@ use_partial_matching=true
 # won't continue if it was set to 'false'.
 #
 # Possible values: true, false
-# Default value: true
+# Default value: false
 
 ignore_download_error=false
 

--- a/src/share/default/default-adsorber.conf
+++ b/src/share/default/default-adsorber.conf
@@ -47,7 +47,7 @@ use_partial_matching=true
 # Possible values: true, false
 # Default value: true
 
-ignore_download_error=true
+ignore_download_error=false
 
 
 ## http_proxy, https_proxy
@@ -56,7 +56,7 @@ ignore_download_error=true
 # and 'https_proxy' over the ones specified here.
 #
 # Please note that your ordinary user 'http(s)_proxy' environmental variables won't affect Adsorber
-# as it doesn't run as user but as root user.
+# as it doesn't run as your user but as root.
 #
 # Possible value: address:port (e.g proxy:8080, 127.0.0.1:9050)
 # Default value: Null (not set)


### PR DESCRIPTION
- schedulers (cronjob and systemd) write their output now to `syslog` and `/var/log/adsorber.log`
-  fixed `ignore_download_error` option being ignored